### PR TITLE
Update for Swift 6.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # The path of LLVM build directory
-LLVM_BUILD_DIR="$HOME/OpenSource/swift-project/build/Ninja-ReleaseAssert/llvm-macosx-arm64"
+LLVM_BUILD_DIR="$HOME/OpenSource/SwiftProject/build/Ninja-ReleaseAssert/llvm-macosx-arm64"
 
 DEBUG_FLAGS=(-g -O0)
 RELEASE_FLAGS=(-O3 -DNDEBUG)

--- a/srcs/source-info-import.cpp
+++ b/srcs/source-info-import.cpp
@@ -16,6 +16,7 @@
 
 using namespace llvm;
 using namespace llvm::support;
+using namespace swift::serialization;
 
 #define DEBUG_TYPE "debug"
 


### PR DESCRIPTION
The format of `.swiftsourceinfo` hasn't been changed. Just update to be in sync with 6.1 source code.